### PR TITLE
Wait for binary parser to finish before resolving the promise.

### DIFF
--- a/src/infogram-api.js
+++ b/src/infogram-api.js
@@ -41,13 +41,14 @@ InfogramApi.prototype = {
       basePath += '/';
     }
 
-    var req = method('https://' + this.base.hostname + basePath + path);
-
     var requestParams = _.extend(_.clone(params), {
       api_key: this.apiKey
     });
 
     requestParams.format = requestParams.format || 'json';
+    var req = method('https://' + this.base.hostname + basePath + path)
+      .accept(requestParams.format)
+      .type(requestParams.format);
 
     var requestOptions = {
       hostname: this.base.hostname,

--- a/src/infogram-api.js
+++ b/src/infogram-api.js
@@ -130,7 +130,7 @@ function binaryParser (res, callback) {
     res.data += chunk;
   });
   res.on('end', function () {
-    callback(null, new Buffer(res.data, 'binary'));
+    callback(null, Buffer.from(res.data, 'binary'));
   });
 }
 

--- a/src/infogram-api.js
+++ b/src/infogram-api.js
@@ -79,7 +79,7 @@ InfogramApi.prototype = {
         }
 
         if (requestParams.format !== 'json') {
-          req.parse(binaryParser);
+          req.buffer(true).parse(binaryParser);
         }
 
         req.end(function (err, res) {


### PR DESCRIPTION
- New buffer is deprecated use Buffer.from
-  Add correct content type and accept header, superagent will create the correct mime-type based on the format string
- Without calling `.buffer(true)` before `.parse(binaryParser)` the promise was being resolved before the `binaryParser` finished